### PR TITLE
修复无法正常获取服务器启动状态与玩家NBT数据转JSON解析失败的Bug

### DIFF
--- a/zhongbais_data_api/entry.py
+++ b/zhongbais_data_api/entry.py
@@ -1,5 +1,6 @@
 import time
 import fnmatch
+from typing import Optional, Any
 from mcdreforged.api.all import *
 
 from zhongbais_data_api.config import Config
@@ -28,15 +29,17 @@ def _is_bot_name(player: str, pattern: str) -> bool:
     return patt_l in name_l
 
 
-def on_load(server: PluginServerInterface, prev):
+def on_load(server: PluginServerInterface, prev: Optional[Any]):
     global _config, __mcdr_server, get_dat
     __mcdr_server = server
     _config = __mcdr_server.load_config_simple(target_class=Config)
     GlobalContext(__mcdr_server, _config)
     get_dat.init_mcdr()
     if prev is not None and hasattr(prev, "get_dat"):
-        get_dat._player_info_callback = prev.get_dat._player_info_callback
-        get_dat._player_list_callback = prev.get_dat._player_list_callback
+        get_dat._player_info_callbacks = prev.get_dat._player_info_callbacks # type: ignore
+        get_dat._player_list_callbacks = prev.get_dat._player_list_callbacks # type: ignore
+    if server.is_server_running():
+        get_dat.start()
 
 
 def on_server_startup(_):
@@ -47,9 +50,9 @@ def on_server_startup(_):
 def on_unload(_):
     get_dat.stop()
     if get_dat.wait_until_stopped(3):
-        __mcdr_server.logger.info("Plugin Exit Finish!")
+        __mcdr_server.logger.info("Plugin Exit Finish!") # type: ignore[union-attr]
     else:
-        __mcdr_server.logger.error("Plugin Exited but GetPos Service Can't Exit!")
+        __mcdr_server.logger.error("Plugin Exited but GetPos Service Can't Exit!") 
 
 
 # 在线玩家检测

--- a/zhongbais_data_api/get_data.py
+++ b/zhongbais_data_api/get_data.py
@@ -148,7 +148,7 @@ class GetDat:
                         f"[GetDat] JSON parse failed for {name}: {pe}"
                     )
                     if getattr(self._config, "debug", False):
-                        try
+                        try:
                             err_col = getattr(pe, 'colno', None)
                             if err_col is None:
                                 err_col = max(0, len(json_str) // 2)
@@ -240,17 +240,15 @@ class GetDat:
         s = re.sub(r"(-?\d+)\s*[bBsSlL]", r"\1", s)
         # 5) 处理省略号 <...> 为合法空列表 []
         s = re.sub(r'<\.\.\.>', r'""', s)
-        # 6) 处理字符串引号：重点修复内层双引号的转义
-        # 单引号包裹的字符串（如 'abc"def' → "abc\"def"）
-        s = re.sub(r"'(.*?)'", 
-            lambda m: '"' + m.group(1).replace('"', r'\"').replace('\\', r'\\') + '"', 
-            s, 
-            flags=re.DOTALL
-        )
-        # 双引号包裹的字符串（如 "abc\"def" → 确保内部转义正确）
-        s = re.sub(r'"(.*?)"', 
-            lambda m: '"' + m.group(1).replace('"', r'\"').replace('\\', r'\\') + '"', 
-            s, 
-            flags=re.DOTALL
-        )
+        # # 6) 处理字符串引号：重点修复内层双引号的转义
+        # # 单引号包裹的字符串（如 'abc"def' → "abc\"def"）
+        # s = re.sub(r"'(.*?)'", 
+        #     lambda m: '"' + m.group(1).replace('"', r'\"').replace('\\', r'\\') + '"', 
+        #     s, 
+        #     flags=re.DOTALL
+        # )
+        def escape_str(match):
+            raw_str = match.group(1)  # 获取单引号内的原始字符串
+            return json.dumps(raw_str)  # 自动处理双引号、反斜杠等转义
+        s = re.sub(r"'(.*?)'", escape_str, s, flags=re.DOTALL)
         return s

--- a/zhongbais_data_api/get_data.py
+++ b/zhongbais_data_api/get_data.py
@@ -95,6 +95,8 @@ class GetDat:
         # 在服务器未启动或 RCON 未就绪时忽略手动刷新
         if not self._server_started or not self._server or not self._server.is_rcon_running():
             try:
+                if getattr(self._config, "debug", False):
+                    self._server.logger.info(f"[GetDat] server_started：{self._server_started} server: { self._server} server.is_rcon_running: { self._server.is_rcon_running()}")
                 self._server.logger.info("[GetDat] manual_fetch ignored: server not started or RCON not ready")
             except Exception:
                 pass
@@ -128,6 +130,8 @@ class GetDat:
                 json_str: Optional[str] = None
                 try:
                     json_str = self._nbt_to_json(raw_nbt)
+                    if json_str.count("{") != json_str.count("}"):
+                        self._server.logger.error(f"[GetDat] json_str括号未闭合{'{'}数量{json_str.count('{')} ,{'}'}数量{json_str.count('}')}")
                     data: Dict[str, Any] = json.loads(json_str)
                     self._dispatch_player_info(name, data)
                     # 收集少量基础信息用于调试
@@ -144,6 +148,19 @@ class GetDat:
                         f"[GetDat] JSON parse failed for {name}: {pe}"
                     )
                     if getattr(self._config, "debug", False):
+                        try
+                            err_col = getattr(pe, 'colno', None)
+                            if err_col is None:
+                                err_col = max(0, len(json_str) // 2)
+                            err_col = min(err_col, len(json_str) - 1) if json_str else 0
+                            start = max(0, err_col - 50)
+                            end = min(len(json_str), err_col + 50)
+                            context = json_str[start:end]
+                            self._server.logger.error(
+                                f"[GetDat] Error position (col {err_col}): ...{context}..."
+                            )
+                        except Exception:
+                            pass
                         snippet_src = (raw_nbt or "")[:300]
                         snippet_json = (json_str or "")[:300]
                         self._server.logger.info(
@@ -221,4 +238,6 @@ class GetDat:
         s = re.sub(r"(-?\d+\.\d+)\s*[dDfF]", r"\1", s)
         # 4) 去掉整数/字节/短整型/长整型后缀 bBsSlL
         s = re.sub(r"(-?\d+)\s*[bBsSlL]", r"\1", s)
+        # 5) 处理省略号 <...> 为合法空列表 []
+        s = re.sub(r'<\.\.\.>', r'""', s)
         return s

--- a/zhongbais_data_api/get_data.py
+++ b/zhongbais_data_api/get_data.py
@@ -240,4 +240,17 @@ class GetDat:
         s = re.sub(r"(-?\d+)\s*[bBsSlL]", r"\1", s)
         # 5) 处理省略号 <...> 为合法空列表 []
         s = re.sub(r'<\.\.\.>', r'""', s)
+        # 6) 处理字符串引号：重点修复内层双引号的转义
+        # 单引号包裹的字符串（如 'abc"def' → "abc\"def"）
+        s = re.sub(r"'(.*?)'", 
+            lambda m: '"' + m.group(1).replace('"', r'\"').replace('\\', r'\\') + '"', 
+            s, 
+            flags=re.DOTALL
+        )
+        # 双引号包裹的字符串（如 "abc\"def" → 确保内部转义正确）
+        s = re.sub(r'"(.*?)"', 
+            lambda m: '"' + m.group(1).replace('"', r'\"').replace('\\', r'\\') + '"', 
+            s, 
+            flags=re.DOTALL
+        )
         return s


### PR DESCRIPTION
### 修复

#### 问题1
修复了在服务器启动状态下加载插件导致无法正常获取服务器启动状态的Bug
`由于on_server_startup 只会在MCDR启动服务器后调用，所以本次简单但不优雅的在on_load的时候额外判断服务器运行状态并尝试再次触发on_server_startup方法。`

#### 问题2
修复了当recipes与toBeDisplayed数据量过大时会产生占位符<...>导致JSON解析失败的Bug
修复了NBT标签可能包含形如 "minecraft:custom_name": '"精准采集"'中'"精准采集"'的双层引号导致解析失败的Bug

<img width="548" height="342" alt="image" src="https://github.com/user-attachments/assets/e37533a8-7006-4375-9c9f-1ffd09f12584" />

#### 测试
该修改已在Fabric 1.21.1服务器测试
<img width="1666" height="126" alt="image" src="https://github.com/user-attachments/assets/9957339b-3447-4135-b208-69c57aa99a07" />

### 修改内容
fix：
1.修复了服务器运行状态下从MCDR加载插件导致误判服务器未运行的BUG 
2.修复了无法获取玩家坐标的Bug

feat：
1.增加了玩家坐标解析产生错误时，尝试打印错误附近的内容。（仅调试模式）
2.增加当json未闭合时候的的日志输出。（仅调试模式）